### PR TITLE
wpanusb: enhancement for beagleconnect freedom gateway

### DIFF
--- a/scripts/rmmod.sh
+++ b/scripts/rmmod.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+rmmod wpanusb
+rmmod ieee802154_6lowpan
+rmmod ieee802154_socket
+rmmod mac802154
+rmmod ieee802154
+

--- a/wpanusb.c
+++ b/wpanusb.c
@@ -25,6 +25,7 @@
 #define WPANUSB_ALLOC_DELAY_MS	100	/* delay after failed allocation */
 
 #define VENDOR_OUT		(USB_TYPE_VENDOR | USB_DIR_OUT)
+#define VENDOR_IN		(USB_TYPE_VENDOR | USB_DIR_IN)
 
 #define WPANUSB_VALID_CHANNELS	(0x07FFFFFF)
 
@@ -53,6 +54,17 @@ static int wpanusb_control_send(struct wpanusb *wpanusb, unsigned int pipe,
 	struct usb_device *udev = wpanusb->udev;
 
 	return usb_control_msg(udev, pipe, request, VENDOR_OUT,
+			       0, 0, data, size, 1000);
+}
+
+static int wpanusb_control_recv(struct wpanusb *wpanusb, u8 request, void *data, u16 size)
+{
+	struct usb_device *udev = wpanusb->udev;
+
+	usb_control_msg(udev, usb_sndctrlpipe(udev, 0), request, VENDOR_OUT,
+			       0, 0, data, size, 1000);
+
+	return usb_control_msg(udev, usb_rcvbulkpipe(udev, 1), request, VENDOR_IN,
 			       0, 0, data, size, 1000);
 }
 
@@ -448,6 +460,7 @@ static int wpanusb_get_device_capabilities(struct ieee802154_hw *hw)
 	struct wpanusb *wpanusb = hw->priv;
 	struct usb_device *udev = wpanusb->udev;
 	unsigned char *buffer;
+	uint32_t valid_channels;
 	int ret = 0;
 
 	buffer = kmalloc(IEEE802154_EXTENDED_ADDR_LEN, GFP_KERNEL);
@@ -463,18 +476,26 @@ static int wpanusb_get_device_capabilities(struct ieee802154_hw *hw)
 		return ret;
 	}
 
+	buffer = kmalloc(sizeof(valid_channels), GFP_NOIO);
+	if (!buffer)
+		return -ENOMEM;
+	ret = wpanusb_control_recv(wpanusb, GET_SUPPORTED_CHANNELS, buffer,	sizeof(valid_channels));
+	valid_channels = *(uint32_t *)buffer;
+	if (ret < 0 || !valid_channels) {
+		dev_err(&udev->dev, "failed to fetch valid channels, setting default valid channels\n");
+		valid_channels = WPANUSB_VALID_CHANNELS;
+	}
+
 	/* FIXME: these need to come from device capabilities */
-	hw->flags = IEEE802154_HW_TX_OMIT_CKSUM | IEEE802154_HW_AFILT |
-		    IEEE802154_HW_PROMISCUOUS;
+	hw->flags = IEEE802154_HW_TX_OMIT_CKSUM | IEEE802154_HW_AFILT;
 
 	/* FIXME: these need to come from device capabilities */
 	hw->phy->flags = WPAN_PHY_FLAG_TXPOWER;
 
 	/* Set default and supported channels */
 	hw->phy->current_page = 0;
-	hw->phy->current_channel = 11;
-	/* FIXME: these need to come from device capabilities */
-	hw->phy->supported.channels[0] = WPANUSB_VALID_CHANNELS;
+	hw->phy->current_channel = ffs(valid_channels) - 1; //set to lowest valid channel
+	hw->phy->supported.channels[0] = valid_channels;
 
 	/* FIXME: these need to come from device capabilities */
 	hw->phy->supported.tx_powers = wpanusb_powers;

--- a/wpanusb.h
+++ b/wpanusb.h
@@ -32,7 +32,7 @@ enum wpanusb_requests {
 	SET_FRAME_RETRIES,
 	SET_PROMISCUOUS_MODE,
 	GET_EXTENDED_ADDR,
-	GET_CAPABILITIES,
+	GET_SUPPORTED_CHANNELS,
 };
 
 struct set_channel {


### PR DESCRIPTION
* get valid channels from device
* disable IEEE802154_HW_PROMISCUOUS mode to  disable error is kernel logs
* with the changes Sub-G(with zephyr patch for PA) works without issues
* 2.4G fails at setting channel
* add simple rmmod script to remove assosciated modules, useful during
  driver testing

SubG host(valid channels received from gateway device):

vaishnav@spectre:~/freedom/wpanusb$ sudo ./scripts/modprobe.sh
vaishnav@spectre:~/freedom/wpanusb$ sudo scripts/lowpan.sh 2 1
Using phy phy0 channel 1 PAN ID 0xabcd
IP: 2001:db8::2/64 Short: 0xbee2
Cannot find device "lowpan0"
vaishnav@spectre:~/freedom/wpanusb$ ping6 2001:db8::1
PING 2001:db8::1(2001:db8::1) 56 data bytes
64 bytes from 2001:db8::1: icmp_seq=1 ttl=64 time=67.7 ms
64 bytes from 2001:db8::1: icmp_seq=2 ttl=64 time=39.2 ms
64 bytes from 2001:db8::1: icmp_seq=3 ttl=64 time=40.5 ms
64 bytes from 2001:db8::1: icmp_seq=4 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=5 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=6 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=7 ttl=64 time=39.2 ms
64 bytes from 2001:db8::1: icmp_seq=8 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=9 ttl=64 time=39.2 ms
64 bytes from 2001:db8::1: icmp_seq=10 ttl=64 time=39.0 ms
^C
--- 2001:db8::1 ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9013ms
rtt min/avg/max/mdev = 38.864/42.039/67.686/8.560 ms

vaishnav@spectre:~/freedom/wpanusb$ iwpan phy
wpan_phy phy0
supported channels:
        page 0: 0,1,2,3,4,5,6,7,8,9,10
current_page: 0
current_channel: 1,   906 MHz
tx_power: 3
capabilities:
        iftypes: node
        channels:
                page 0:
                        [ 0] 868.3 MHz, [ 1]   906 MHz, [ 2]   908 MHz,
                        [ 3]   910 MHz, [ 4]   912 MHz, [ 5]   914 MHz,
                        [ 6]   916 MHz, [ 7]   918 MHz, [ 8]   920 MHz,
                        [ 9]   922 MHz, [10]   924 MHz
        tx_powers:
                        3 dBm, 2.8 dBm, 2.3 dBm, 1.8 dBm, 1.3 dBm, 0.7 dBm,
                        0 dBm, -1 dBm, -2 dBm, -3 dBm, -4 dBm, -5 dBm,
                        -7 dBm, -9 dBm, -12 dBm, -17 dBm,
        min_be: 3
        max_be: 5
        csma_backoffs: 4
        frame_retries: 3
        lbt: false

SubG Zephyr Console:

** Booting Zephyr OS version 2.4.99  ***
[00:00:00.005,462] <inf> wpanusb_bc: Starting wpanusb
[00:00:00.006,652] <err> wpanusb_bc: Dropped HDLC crc:f399 len:4
[00:00:00.706,298] <err> wpanusb_bc: RETRY HDLC INIT
[00:00:00.707,427] <inf> wpanusb_bc: HDLC Ready
[00:00:55.224,395] <err> wpanusb_bc: 11: Not handled for now
[00:00:55.229,095] <err> wpanusb_bc: 11: Not handled for now
[00:00:55.251,098] <inf> wpanusb_bc: pan id : FFFF
[00:00:55.255,737] <inf> wpanusb_bc: short addr : FFFF
[00:00:55.256,958] <inf> wpanusb_bc: Start IEEE 802.15.4 device
[00:01:06.258,544] <inf> wpanusb_bc: Stop IEEE 802.15.4 device
[00:01:06.268,096] <inf> wpanusb_bc: page 0 channel 1
[00:01:06.275,634] <inf> wpanusb_bc: pan id : ABCD
[00:01:06.278,930] <inf> wpanusb_bc: short addr : BEE2
[00:01:06.282,104] <inf> wpanusb_bc: Start IEEE 802.15.4 device
[00:01:48.053,558] <inf> wpanusb_bc: Stop IEEE 802.15.4 device
